### PR TITLE
cas:serviceResponse multiple xml nodes with the same tag_name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+#vim
+*.swp
+

--- a/cas_client/_version.py
+++ b/cas_client/_version.py
@@ -1,3 +1,3 @@
-__version_info__ = (1, 0, 0)
+__version_info__ = (1, 1, 0)
 
 __version__ = '.'.join(str(_) for _ in __version_info__)

--- a/cas_client/cas_client.py
+++ b/cas_client/cas_client.py
@@ -570,7 +570,14 @@ class CASResponse(object):
                     result[tag_name] = text
             elif child.nodeType == child.ELEMENT_NODE:
                 subresult = cls._parse_cas_xml_data(child)
-                result.setdefault(tag_name, {}).update(subresult)
+                element=result.setdefault(tag_name, {})
+                for key in subresult.keys():
+                    if key in element:
+                        if not isinstance(element[key], list):
+                            element[key] = [ element[key] ]
+                        element[key].append(subresult[key])
+                    else:
+                        element.update(subresult)
         return result
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -15,6 +15,8 @@ except ImportError:
 
 class TestCase(unittest.TestCase):
 
+    maxDiff = None
+
     response_text = """
     <cas:serviceResponse xmlns:cas='http://www.yale.edu/tp/cas'>
         <cas:authenticationSuccess>
@@ -25,6 +27,8 @@ class TestCase(unittest.TestCase):
                 <cas:lastname>Ott</cas:lastname>
                 <cas:firstname>Jeffrey A</cas:firstname>
                 <cas:fullname>Jeffrey A Ott</cas:fullname>
+                <cas:role>user</cas:role>
+                <cas:role>manager</cas:role>
                 <cas:puid>0012345678</cas:puid>
             </cas:attributes>
         </cas:authenticationSuccess>
@@ -63,6 +67,7 @@ class TestCase(unittest.TestCase):
     def test_success(self):
         response = CASResponse(self.response_text)
         self.assertTrue(response.success)
+        self.assertListEqual(response.attributes[u'role'], [ u'user', u'manager' ])
         self.assertEqual(response.attributes, {
             u'i2a2characteristics': u'0,3592,2000',
             u'puid': u'0012345678',
@@ -70,6 +75,7 @@ class TestCase(unittest.TestCase):
             u'lastname': u'Ott',
             u'fullname': u'Jeffrey A Ott',
             u'email': u'jott@purdue.edu',
+            u'role': [ u'user', u'manager' ],
         })
         self.assertEqual(response.response_type, 'authenticationSuccess')
         self.assertEqual(response.user, 'jott')
@@ -100,6 +106,7 @@ class TestCase(unittest.TestCase):
             u'lastname': u'Ott',
             u'fullname': u'Jeffrey A Ott',
             u'email': u'jott@purdue.edu',
+            u'role': [ u'user', u'manager' ],
         })
         self.assertEqual(response.response_type, 'authenticationSuccess')
         self.assertEqual(response.user, 'jott')
@@ -119,6 +126,7 @@ class TestCase(unittest.TestCase):
                 headers=None
             )
         self.assertTrue(response.success)
+        self.assertListEqual(response.attributes[u'role'], [ u'user', u'manager' ])
         self.assertEqual(response.attributes, {
             u'i2a2characteristics': u'0,3592,2000',
             u'puid': u'0012345678',
@@ -126,6 +134,7 @@ class TestCase(unittest.TestCase):
             u'lastname': u'Ott',
             u'fullname': u'Jeffrey A Ott',
             u'email': u'jott@purdue.edu',
+            u'role': [ u'user', u'manager' ],
         })
         self.assertEqual(response.response_type, 'authenticationSuccess')
         self.assertEqual(response.user, 'jott')


### PR DESCRIPTION
Fixes #14
If <cas:attributes> under <cas:serviceResponse> contains multiple nodes with the same tag_name, their values are accessible as python List.
```
<cas:attributes>
     <cas:firstName>John</cas:firstName>
     <cas:role>user</cas:role>
     <cas:role>manager</cas:role>
[...]
```
```
response.attributes['role'] == [ 'user', 'manager' ]
```